### PR TITLE
fix: update aarch64 detection in download script

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -21,7 +21,9 @@ case "$uname_s" in
 Darwin) os="apple-darwin" ;;
 Linux)
 	os="unknown-linux-gnu"
-	if [ "$uname_m" = "armv7l" ]; then
+	if [ "$uname_m" = "aarch64" ]; then
+		os="unknown-linux-musl"
+	elif [ "$uname_m" = "armv7l" ]; then
 		uname_m="armv7"
 		os="${os}eabihf"
 	fi


### PR DESCRIPTION
## Fix installation on aarch64 Linux systems

## Description

This PR fixes the installation failure on aarch64 Linux systems by using the `unknown-linux-musl` target instead of the hardcoded `unknown-linux-gnu` target. The change modifies the `bin/download` script to detect aarch64 architecture and select the appropriate musl binary, which is the available distribution format from the upstream UV project.

## Motivation and Context

Fixes #16

UV stopped distributing the `aarch64-unknown-linux-gnu` binary (see [astral-sh/uv#3761](https://github.com/astral-sh/uv/pull/3761)), but this plugin had a hardcoded dependency for `unknown-linux-gnu` for all Linux systems. This caused installation failures on aarch64 Linux systems with a 404 error when attempting to download the binary.

The upstream UV project only distributes `aarch64-unknown-linux-musl` binaries for aarch64 Linux, not the gnu variant.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

After this fix, users on aarch64 Linux systems can successfully install UV:

```bash
asdf plugin add uv
asdf install uv latest
asdf global uv latest
```

The plugin will now correctly download `uv-aarch64-unknown-linux-musl.tar.gz` instead of attempting to download the non-existent `uv-aarch64-unknown-linux-gnu.tar.gz`.

## How Has This Been Tested?

The logic has been verified to:
- Correctly detect aarch64 architecture on Linux systems
- Select `unknown-linux-musl` target for aarch64
- Maintain existing behavior for x86_64 (`unknown-linux-gnu`)
- Maintain existing behavior for armv7l (`armv7-unknown-linux-gnueabihf`)
- Maintain existing behavior for macOS Darwin targets

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
